### PR TITLE
Feature "setHeader()"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Add the following to your `composer.json` file :
 <a name="block2"></a>
 ## 2. Methods available
 
+- $this->setHeader($field,$value);
+- $this->setHeaders($headers);
+- $this->setAcceptLanguage($lang = 'en');
 - $this->setAcceptLanguage($lang = 'en');
 - $this->setAcceptEncoding($value = 'gzip');
 - $this->setUserAgent($agentString);
@@ -52,7 +55,10 @@ $url = 'http://api.duckduckgo.com/?q=DuckDuckGo&format=json&pretty=1';
 
 $client = new RestfulClient();
 
-// (Optional) Set some headers
+// (Optional) Directly set a header field
+$client->setHeader('Content-Type', 'application/json');
+
+// (Optional) Set some headers with convenient functions
 $client->setAcceptLanguage('ca,en;q=0.8,es;q=0.6')
        ->setAcceptEncoding('gzip,deflate,sdch')
        ->setUserAgent('Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.2 Safari/537.36');
@@ -162,7 +168,6 @@ array(3) {
 ## 4. To do
 
 ### Better methods
-- Allow adding extra headers using $this->setHeader('name','value');
 - For file get contents, follow 301 and 302 codes and throw request again at the returned URL.
 
 ### Better testing

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Add the following to your `composer.json` file :
 - $this->setHeader($field,$value);
 - $this->setHeaders($headers);
 - $this->setAcceptLanguage($lang = 'en');
-- $this->setAcceptLanguage($lang = 'en');
 - $this->setAcceptEncoding($value = 'gzip');
 - $this->setUserAgent($agentString);
 - $this->setBasicAuthorization($username,$password);

--- a/src/Sonrisa/Component/RestfulClient/Interfaces/RestfulClientInterface.php
+++ b/src/Sonrisa/Component/RestfulClient/Interfaces/RestfulClientInterface.php
@@ -10,6 +10,12 @@ namespace Sonrisa\Component\RestfulClient\Interfaces;
 interface RestfulClientInterface
 {
     /**
+     * @param $field
+     * @param $value
+     * @return \Sonrisa\Component\RestfulClient\Interfaces\RestfulClientInterface
+     */
+    public function setHeader($field, $value);
+    /**
      * Sets the default response language.
      *
      * @param  string                                                                  $lang

--- a/src/Sonrisa/Component/RestfulClient/RestfulClient.php
+++ b/src/Sonrisa/Component/RestfulClient/RestfulClient.php
@@ -160,7 +160,7 @@ class RestfulClient implements RestfulClientInterface
      */
     public function setBasicAuthorization($username,$password)
     {
-        $this->setHeader('Authorization', base64_encode("$username:$password"));
+        $this->setHeader('Authorization', "Basic " . base64_encode("$username:$password"));
 
         return $this;
     }

--- a/src/Sonrisa/Component/RestfulClient/RestfulClient.php
+++ b/src/Sonrisa/Component/RestfulClient/RestfulClient.php
@@ -81,6 +81,33 @@ class RestfulClient implements RestfulClientInterface
     }
 
     /**
+     * Sets a custom header field.
+     *
+     * @param $token
+     * @param string $type
+     * @return RestfulClient
+     */
+    public function setHeader($field, $value)
+    {
+        $this->headers[ $field ] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Sets multiple custom header fields identified by array keys and values
+     *
+     * @param $headers
+     */
+    public function setHeaders($headers)
+    {
+        // Note: We could of course also do an array_merge($this->headers, $headers)
+        foreach ($headers as $key => $value) {
+            $this->setHeader($key, $value);
+        }
+    }
+
+    /**
      * Sets the default response language.
      *
      * @param  string $lang
@@ -93,7 +120,7 @@ class RestfulClient implements RestfulClientInterface
             throw new RestfulClientException('The language code cannot be empty or NULL');
         }
 
-        $this->headers['Accept-language'] = $lang;
+        $this->setHeader('Accept-language', $lang);
 
         return $this;
     }
@@ -106,7 +133,7 @@ class RestfulClient implements RestfulClientInterface
      */
     public function setAcceptEncoding($value = 'compress, gzip')
     {
-        $this->headers['Accept-Encoding'] = $value;
+        $this->setHeader('Accept-Encoding', $value);
 
         return $this;
     }
@@ -119,7 +146,7 @@ class RestfulClient implements RestfulClientInterface
      */
     public function setUserAgent($agentString)
     {
-        $this->headers['User-Agent'] = $agentString;
+        $this->setHeader('User-Agent', $agentString);
 
         return $this;
     }
@@ -128,16 +155,15 @@ class RestfulClient implements RestfulClientInterface
      * (Optional) Sets a Basic Authorization in every request.
      *
      * @param $username
-     * @param $password     
+     * @param $password
      * @return RestfulClient
      */
     public function setBasicAuthorization($username,$password)
     {
-        $this->headers['Authorization'] = "Basic " . base64_encode("$username:$password");
+        $this->setHeader('Authorization', base64_encode("$username:$password"));
 
-        return $this;         
+        return $this;
     }
-
 
     /**
      * (Optional) It will set the API's key or token value and will be send in every client request.

--- a/tests/Sonrisa/Component/RestfulClient/RestfulClientTest.php
+++ b/tests/Sonrisa/Component/RestfulClient/RestfulClientTest.php
@@ -9,11 +9,47 @@
 
 class RestfulClientTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \Sonrisa\Component\RestfulClient\RestfulClient $client
+     */
     protected $client;
 
     public function setUp()
     {
         $this->client = new \Sonrisa\Component\RestfulClient\RestfulClient();
+    }
+
+    public function testSetHeader()
+    {
+        $useContentType = 'application/json; charset=utf-8';
+        $this->client->setHeader('Content-Type', $useContentType);
+
+        $reflection = new \ReflectionClass($this->client);
+        $property = $reflection->getProperty("headers");
+        $property->setAccessible(true);
+
+        $array = $property->getValue($this->client);
+        $this->assertEquals($useContentType, $array['Content-Type']);
+    }
+
+    public function testSetHeaders()
+    {
+        $headers = array(
+            'User-Agent' => 'Mozilla/5.0',
+            'Origin' => 'http://my-lovely-host:3000'
+        );
+
+        $this->client->setHeaders($headers);
+
+        $reflection = new \ReflectionClass($this->client);
+        $property = $reflection->getProperty("headers");
+        $property->setAccessible(true);
+
+        $array = $property->getValue($this->client);
+
+        foreach($headers as $key => $value) {
+            $this->assertEquals($value, $array[$key]);
+        }
     }
 
     public function testSetAcceptEncoding()


### PR DESCRIPTION
Hi Nil,

after quite some time silently using your restclient-component in one of my projects, I faced the need for setting custom authentication headers for "Bearer" tokens, so instead of switching to another component I quickly decided to implement a simple setHeader() and setHeaders() method for setting any kind of custom headers. It's something that already was on your TODO list, so this should fit to your original plan... :)

I integrated some tests and slightly updated the README to match the updated situation. I would appreciate if you merge this request and bump the version (1.1.0 or 1.0.1?). 

Thanks in advance and happy hacking,
Matthias


