### PR TITLE
Fix (#9): http methods beyond GET and POST don't work for curl client.

### DIFF
--- a/src/CURLClient.php
+++ b/src/CURLClient.php
@@ -51,7 +51,7 @@ class CURLClient extends AbstractClient implements ClientInterface
             if ($methodName == 'GET') {
                 $url = $url . "?" . http_build_query($params);
                 curl_setopt($this->curl, CURLOPT_URL, $url);
-            } elseif ($methodName == 'POST') {
+            } else {
 
                 $contentType = null;
 
@@ -72,12 +72,14 @@ class CURLClient extends AbstractClient implements ClientInterface
 
                 curl_setopt($this->curl, CURLOPT_URL, $url);
                 curl_setopt($this->curl, CURLOPT_POSTFIELDS, $postContent);
-                curl_setopt($this->curl, CURLOPT_POST, true);
-            } elseif ($methodName == 'PUT') {
-                curl_setopt($this->curl, CURLOPT_URL, $url);
-            } else {
+                // Always set method as passed in $methodName - so we don't need shortcuts like CURLOPT_POST
                 curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, $methodName);
-                curl_setopt($this->curl, CURLOPT_HTTPHEADER, array("X-HTTP-Method-Override: {$methodName}"));
+
+                if (! in_array($methodName, array('GET', 'POST'))) {
+                    // As default as X-HHTP-Method-Overide header for http verbs other than GET and POST
+                    // so that APIs behind a permissive firewall have a chance to detect request method:
+                    curl_setopt($this->curl, CURLOPT_HTTPHEADER, array("X-HTTP-Method-Override: {$methodName}"));
+                }
             }
 
             //Prepare headers and related config.

--- a/tests/AbstractClientTest.php
+++ b/tests/AbstractClientTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Sonrisa\Test\Component\RestfulClient;
+use Sonrisa\Component\RestfulClient\Interfaces\RestfulClientInterface;
 
 /**
  * Author:  Nil Portugués Calderó <contact@nilportugues.com>
@@ -12,6 +13,7 @@ namespace Sonrisa\Test\Component\RestfulClient;
 
 abstract class AbstractClientTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var RestfulClientInterface $client */
     protected $client;
     protected $params;
     protected $headers;
@@ -37,7 +39,7 @@ abstract class AbstractClientTest extends \PHPUnit_Framework_TestCase
     {
         $methodName = 'GET';
         $url = 'http://api.duckduckgo.com/?q=DuckDuckGo&format=json&pretty=1';
-        $params = array('count'=>2 );
+        $params = array('count' => 2);
         $headers = $this->headers;
 
         $response = $this->client->request($methodName, $url, $params, $headers);
@@ -69,10 +71,10 @@ abstract class AbstractClientTest extends \PHPUnit_Framework_TestCase
         $methodName = 'GET';
         $url = 'https://httpbin.org/get?show_env=1';
         $params = array();
-        $headers = array(
+        $headers = array_merge($this->headers, array(
             'Authorization' => 'Bearer this1is2not3really4a5valid6token',
             'Content-Type' => 'application/json'
-        );
+        ));
 
         $response = $this->client->request($methodName, $url, $params, $headers);
 
@@ -85,79 +87,93 @@ abstract class AbstractClientTest extends \PHPUnit_Framework_TestCase
     public function testValidPOSTRequest()
     {
         $methodName = 'POST';
-        $url = 'http://api.duckduckgo.com/?q=DuckDuckGo&format=json&pretty=1';
-        $params = array( 'track' => 'twitter' );
-        $headers = $this->headers;
+        $url = 'https://httpbin.org/post';
+        $testData = array('foo' => array('bar' => 'baz'));
+        $params = $testData;
+        $headers = array_merge($this->headers, array(
+            'Content-Type' => 'application/json'
+        ));
 
         $response = $this->client->request($methodName, $url, $params, $headers);
 
         $this->assertArrayHasKey('Protocol', $response['headers']);
         $this->assertArrayHasKey('Status', $response['headers']);
+
+        $this->assertEquals(200, $response['headers']['Status']);
+        $this->assertEquals($testData, $response['response']['json']);
     }
 
     public function testValidPUTRequest()
     {
         $methodName = 'PUT';
-        $url = 'http://api.duckduckgo.com/?q=DuckDuckGo&format=json&pretty=1';
-        $params = array( 'track' => 'twitter' );
-        $headers = $this->headers;
+        $url = 'https://httpbin.org/put';
+        $testData = array('foo' => array('bar' => 'baz'));
+        $params = $testData;
+        $headers = array_merge($this->headers, array(
+            'Content-Type' => 'application/json'
+        ));
 
         $response = $this->client->request($methodName, $url, $params, $headers);
 
         $this->assertArrayHasKey('Protocol', $response['headers']);
         $this->assertArrayHasKey('Status', $response['headers']);
+
+        $this->assertEquals(200, $response['headers']['Status']);
+        $this->assertEquals($testData, $response['response']['json']);
     }
 
     public function testValidPATCHRequest()
     {
         $methodName = 'PATCH';
-        $url = 'http://api.duckduckgo.com/?q=DuckDuckGo&format=json&pretty=1';
-        $params = array( 'track' => 'twitter' );
-        $headers = $this->headers;
+        $url = 'https://httpbin.org/patch';
+        $testData = array('foo' => array('bar' => 'baz'));
+        $params = $testData;
+        $headers = array_merge($this->headers, array(
+            'Content-Type' => 'application/json'
+        ));
 
         $response = $this->client->request($methodName, $url, $params, $headers);
 
         $this->assertArrayHasKey('Protocol', $response['headers']);
         $this->assertArrayHasKey('Status', $response['headers']);
+
+        $this->assertEquals(200, $response['headers']['Status']);
+        $this->assertEquals($testData, $response['response']['json']);
     }
 
     public function testValidDELETERequest()
     {
         $methodName = 'DELETE';
-        $url = 'http://api.duckduckgo.com/?q=DuckDuckGo&format=json&pretty=1';
-        $params = array( 'track' => 'twitter' );
-        $headers = $this->headers;
+        $url = 'https://httpbin.org/delete';
+        $testData = array('foo' => array('bar' => 'baz'));
+        $params = $testData;
+        $headers = array_merge($this->headers, array(
+            'Content-Type' => 'application/json'
+        ));
 
         $response = $this->client->request($methodName, $url, $params, $headers);
 
         $this->assertArrayHasKey('Protocol', $response['headers']);
         $this->assertArrayHasKey('Status', $response['headers']);
-    }
 
-    public function testValidHEADRequest()
-    {
-        $methodName = 'HEAD';
-        $url = 'http://api.duckduckgo.com/?q=DuckDuckGo&format=json&pretty=1';
-        $params = array( 'track' => 'twitter' );
-        $headers = $this->headers;
-
-        $response = $this->client->request($methodName, $url, $params, $headers);
-
-        $this->assertArrayHasKey('Protocol', $response['headers']);
-        $this->assertArrayHasKey('Status', $response['headers']);
+        $this->assertEquals(200, $response['headers']['Status']);
+        $this->assertEquals($testData, $response['response']['json']);
     }
 
     public function testValidOPTIONSRequest()
     {
         $methodName = 'OPTIONS';
         $url = 'http://api.duckduckgo.com/?q=DuckDuckGo&format=json&pretty=1';
-        $params = array( 'track' => 'twitter' );
+        $params = array();
         $headers = $this->headers;
 
         $response = $this->client->request($methodName, $url, $params, $headers);
 
         $this->assertArrayHasKey('Protocol', $response['headers']);
         $this->assertArrayHasKey('Status', $response['headers']);
+
+        // "Not Allowed" is what duckduckgo currently returns for OPTIONS
+        $this->assertEquals(405, $response['headers']['Status']);
     }
 
     public function testValidCUSTOMRequest()
@@ -171,6 +187,9 @@ abstract class AbstractClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('Protocol', $response['headers']);
         $this->assertArrayHasKey('Status', $response['headers']);
+
+        // "Not Allowed" is what duckduckgo currently returns for unknown http methods
+        $this->assertEquals(405, $response['headers']['Status']);
     }
 
     public function tearDown()


### PR DESCRIPTION
Here's the patch: I simplified and streamlined the curl_set_* calls for the CURLClient: Now *url* and *custom-request* is set in every case. The override header (X-HTTP-Method-Override) is set additionally if method diverges from GET and POST. 

Furthermore I added and adjusted a couple of tests to cover at least the successful execution of specific http methods (pretty nice testing possibility when using httpbin and endpoints named like the http verb). I kicked the test for the HEAD method because for some reason the FileGetContentsClient took some endless 10 seconds for executing this... Guess we may reintegrate that as soon as we're going to cover *all* http verbs. Most important should be covered now though.

Thanks for merging (if you aggree)...!
Matthias
 